### PR TITLE
Ensure the asset catalog parser ignores types we don't support (for now)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# StencilSwiftKit CHANGELOG
+
+---
+
+## Master
+
+### Bug Fixes
+
+* Asset catalog parser: ignore unsupported types (such as appiconset).  
+  [David Jennes](https://github.com/djbe)
+  [#7](https://github.com/SwiftGen/StencilSwiftKit/issues/7)
+
+### New Features
+
+### Internal Changes

--- a/Sources/Parsers/AssetsCatalogParser.swift
+++ b/Sources/Parsers/AssetsCatalogParser.swift
@@ -38,23 +38,9 @@ private enum AssetCatalog {
   static let root = "com.apple.actool.catalog-contents"
   
   enum Extension {
-    static let appIconSet = "appiconset"
-    static let dataSet = "dataset"
-    static let gameCenterDashboardImage = "gcdashboardimage"
-    static let gameCenterLeaderboard = "gcleaderboard"
-    static let gameCenterLeaderboardSet = "gcleaderboardset"
-    static let iconSet = "iconset"
     static let imageSet = "imageset"
-    static let imageStack = "imagestack"
-    static let launchImage = "launchimage"
-    static let spriteAtlas = "spriteatlas"
-    static let stickerPack = "stickerpack"
-    
-    static let unsupported = [
-      appIconSet, dataSet, gameCenterDashboardImage, gameCenterLeaderboard,
-      gameCenterLeaderboardSet, iconSet, imageSet, imageStack, launchImage,
-      spriteAtlas, stickerPack
-    ]
+	
+    static let supported = [imageSet]
   }
 }
 
@@ -105,7 +91,7 @@ extension AssetsCatalogParser {
         let imageName = path.lastComponentWithoutExtension
 
         result += [.image(name: imageName, value: "\(prefix)\(imageName)")]
-      } else if path.extension == nil || !AssetCatalog.Extension.unsupported.contains(path.extension ?? "") {
+      } else if path.extension == nil || AssetCatalog.Extension.supported.contains(path.extension ?? "") {
         // this is a group/folder
         let children = item[AssetCatalog.children] as? [[String: Any]] ?? []
 

--- a/Sources/Parsers/AssetsCatalogParser.swift
+++ b/Sources/Parsers/AssetsCatalogParser.swift
@@ -40,6 +40,16 @@ private enum AssetCatalog {
   enum Extension {
     static let imageSet = "imageset"
 	
+	/**
+	 * This is a list of supported asset catalog item types, for now we just
+	 * support `image set`s. If you want to add support for new types, just add
+	 * it to this whitelist, and add the necessary code to the
+	 * `process(items:withPrefix:)` method.
+	 *
+	 * Note: The `actool` utility that we use for parsing hase some issues. Check
+	 * this issue for more information:
+	 * https://github.com/SwiftGen/SwiftGen/issues/228
+	 */
     static let supported = [imageSet]
   }
 }

--- a/Sources/Parsers/AssetsCatalogParser.swift
+++ b/Sources/Parsers/AssetsCatalogParser.swift
@@ -36,11 +36,29 @@ private enum AssetCatalog {
   static let filename = "filename"
   static let providesNamespace = "provides-namespace"
   static let root = "com.apple.actool.catalog-contents"
+  
+  enum Extension {
+    static let appIconSet = "appiconset"
+    static let dataSet = "dataset"
+    static let gameCenterDashboardImage = "gcdashboardimage"
+    static let gameCenterLeaderboard = "gcleaderboard"
+    static let gameCenterLeaderboardSet = "gcleaderboardset"
+    static let iconSet = "iconset"
+    static let imageSet = "imageset"
+    static let imageStack = "imagestack"
+    static let launchImage = "launchimage"
+    static let spriteAtlas = "spriteatlas"
+    static let stickerPack = "stickerpack"
+    
+    static let unsupported = [
+      appIconSet, dataSet, gameCenterDashboardImage, gameCenterLeaderboard,
+      gameCenterLeaderboardSet, iconSet, imageSet, imageStack, launchImage,
+      spriteAtlas, stickerPack
+    ]
+  }
 }
 
 extension AssetsCatalogParser {
-  static let imageSetExtension = "imageset"
-
   /**
    This method recursively parses a tree of nodes (similar to a directory structure)
    resulting from the `actool` utility.
@@ -82,12 +100,12 @@ extension AssetsCatalogParser {
       guard let filename = item[AssetCatalog.filename] as? String else { continue }
       let path = Path(filename)
 
-      if path.extension == AssetsCatalogParser.imageSetExtension {
+      if path.extension == AssetCatalog.Extension.imageSet {
         // this is a simple imageset
         let imageName = path.lastComponentWithoutExtension
 
         result += [.image(name: imageName, value: "\(prefix)\(imageName)")]
-      } else {
+      } else if path.extension == nil || !AssetCatalog.Extension.unsupported.contains(path.extension ?? "") {
         // this is a group/folder
         let children = item[AssetCatalog.children] as? [[String: Any]] ?? []
 


### PR DESCRIPTION
Fixes #6.

We should consider eventually supporting the other types. For example: use [`setAlternateIconName(_:completionHandler:)`](https://developer.apple.com/reference/uikit/uiapplication/2806818-setalternateiconname) for app icon sets.