### PR TITLE
Avoid color conversion if possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ### Bug Fixes
 
-_None_
+* Don't convert colors to the calibrated RGB color space if it isn't needed.
+  [David Jennes](https://github.com/djbe)
+  [#23](https://github.com/SwiftGen/SwiftGenKit/issues/23)
 
 ### Breaking Changes
 

--- a/Sources/Parsers/ColorsFileParser.swift
+++ b/Sources/Parsers/ColorsFileParser.swift
@@ -151,6 +151,8 @@ public final class ColorsCLRFileParser: ColorsFileParser {
 extension NSColor {
 
   fileprivate var rgbColor: NSColor? {
+    guard colorSpace.colorSpaceModel != .RGB else { return self }
+    
     return usingColorSpaceName(NSCalibratedRGBColorSpace)
   }
 

--- a/Sources/Parsers/ColorsFileParser.swift
+++ b/Sources/Parsers/ColorsFileParser.swift
@@ -152,7 +152,7 @@ extension NSColor {
 
   fileprivate var rgbColor: NSColor? {
     guard colorSpace.colorSpaceModel != .RGB else { return self }
-    
+
     return usingColorSpaceName(NSCalibratedRGBColorSpace)
   }
 


### PR DESCRIPTION
Fixes #20.

When we convert a color from any color space to the calibrated RGB color space, we're (potentially) throwing away information. The only reason the conversion is there in the first place, is in case the color is in (for example) grayscale, and thus has no red, green and blue components.

This simply adds a check to avoid conversions if possible. 