### PR TITLE
Fonts: deprecate `fontName` for `name` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ _None_
 * More variables have been deprecated, while new variables have been added.  
   [David Jennes](https://github.com/djbe)
   [#13](https://github.com/SwiftGen/SwiftGenKit/issues/13)
+  [#27](https://github.com/SwiftGen/SwiftGenKit/issues/27)
   * The `strings`, `structuredStrings` and `tableName` have been replaced by `tables`, which is an array of string tables, each with a `name` and a `strings` property.
   * For each string, the `params` variable and it's subvariables (such as `names`, `count`, ...) have been replaced by `types`, which is an array of types.
   * `enumName`, `sceneEnumName` and `segueEnumName` have been replaced by `param.enumName`, `param.sceneEnumName` and `param.segueEnumName` respectively. Templates should provide a default value for these in case the variables are empty.

--- a/Sources/Stencil/FontsContext.swift
+++ b/Sources/Stencil/FontsContext.swift
@@ -22,6 +22,9 @@ extension FontsFileParser {
         // Font
         return [
           "style": font.style,
+          "name": font.postScriptName,
+
+          // NOTE: This is a deprecated variable
           "fontName": font.postScriptName
         ]
       }.sorted { $0["fontName"] ?? "" < $1["fontName"] ?? "" }


### PR DESCRIPTION
Addresses https://github.com/SwiftGen/templates/pull/37#issuecomment-296025531, #5
Related: https://github.com/SwiftGen/templates/pull/39