### PR TITLE
Add XIB Parser and context provider

### DIFF
--- a/Sources/Parsers/XIBParser.swift
+++ b/Sources/Parsers/XIBParser.swift
@@ -1,0 +1,49 @@
+//
+// SwiftGenKit
+// Copyright (c) 2017 SwiftGen
+// MIT Licence
+//
+
+import Foundation
+import PathKit
+
+public final class XIBParser {
+  var xibs: [String: (customClass: String?, module: String?)] = [:]
+
+  public init() {}
+
+  private class ParserDelegate: NSObject, XMLParserDelegate {
+    fileprivate var fileOwnerClass: String?
+    fileprivate var fileOwnerModule: String?
+
+    func parser(_ parser: XMLParser, didStartElement elementName: String,
+                namespaceURI: String?, qualifiedName qName: String?,
+                attributes attributeDict: [String: String]) {
+      if elementName == "placeholder" && attributeDict["placeholderIdentifier"] == "IBFilesOwner" {
+        self.fileOwnerClass = attributeDict["customClass"]
+        self.fileOwnerModule = attributeDict["customModule"]
+      }
+    }
+  }
+
+  public func addXIB(at path: Path) throws {
+    let parser = XMLParser(data: try path.read())
+
+    let delegate = ParserDelegate()
+    parser.delegate = delegate
+    parser.parse()
+
+    let xibName = path.lastComponentWithoutExtension
+    self.xibs[xibName] = (delegate.fileOwnerClass, delegate.fileOwnerModule)
+  }
+
+  public func parseDirectory(at path: Path) throws {
+    let iterator = path.makeIterator()
+
+    while let subPath = iterator.next() {
+      if subPath.extension == "xib" {
+        try addXIB(at: subPath)
+      }
+    }
+  }
+}

--- a/Sources/Stencil/XIBContext.swift
+++ b/Sources/Stencil/XIBContext.swift
@@ -1,0 +1,31 @@
+//
+// SwiftGenKit
+// Copyright (c) 2017 SwiftGen
+// MIT Licence
+//
+
+import Foundation
+
+/*
+ - `xibs`: `Array` — List of xibs
+   - `name`: `String` — Name of the xib
+   - `owner`: `String` — The custom class of the scene
+   - `customModule`: `String` — The custom module of the scene (absent if no custom class)
+ */
+extension XIBParser {
+  public func stencilContext() -> [String: Any] {
+    let xibNames = Set(xibs.keys).sorted(by: <)
+    let xibsMap = xibNames.map { (xibName: String) -> [String: String] in
+      guard let (owner, module) = xibs[xibName] else {
+        return [:]
+      }
+
+      var xibInformation = ["name": xibName]
+      xibInformation["customOwner"] = owner
+      xibInformation["customModule"] = module
+      return xibInformation
+    }
+
+    return ["xibs": xibsMap]
+  }
+}


### PR DESCRIPTION
This is a proposal to add XIB parsers to add support on `SwiftGen` for parsing XIB files. This is particularly useful to add some compiler guarantees around View Controller creation. `UIKit` supports creating view controllers from the same name as the xib file but since this happens on runtime, it'd be nice to support this from `swiftgen`.

I have a commit[0] ready for SwiftGen if this direction gets approved.

[0] https://github.com/Reflejo/SwiftGen/commit/b4c45e0393e65f2d7d119a5df1df5cbd970c2a5e