### PR TITLE
Remove context generation parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## Master
 
+Due to the removal of legacy code, there are a few breaking changes in this new version that affect both template writers as well as developers. We've provided a migration guide to help you through these changes, which you can find here:
+[Migration Guide for 2.0](https://github.com/SwiftGen/SwiftGenKit/blob/master/Documentation/MigrationGuide.md#swiftgenkit-20-swiftgen-50)
+
 ### Bug Fixes
 
 * Fixed color's hex value rounding error.  
@@ -18,6 +21,7 @@
 * Removed deprecated variables. See [SwiftGenKit#5](https://github.com/SwiftGen/SwiftGenKit/issues/5) for more information.   
   [David Jennes](https://github.com/djbe)
   [#35](https://github.com/SwiftGen/templates/issues/35)
+  [#42](https://github.com/SwiftGen/templates/issues/42)
 
 ### New Features
 

--- a/Documentation/MigrationGuide.md
+++ b/Documentation/MigrationGuide.md
@@ -1,0 +1,45 @@
+## SwiftGenKit 2.0 (SwiftGen 5.0)
+
+### For template writers:
+
+#### Colors
+
+- `enumName`: has been replaced by `param.enumName`, should provide default value.
+- For each `color`:
+  - `rgb` and `rgba`: can be composed from the other components.
+
+#### Fonts
+
+- `enumName`: has been replaced by `param.enumName`, should provide default value.
+- For each `font`:
+  - `fontName`: has been replaced by the `name` property.
+
+#### Images
+
+- `enumName`: has been replaced by `param.enumName`, should provide default value.
+- `images`: just old, `catalogs` contains the structured information.
+
+#### Storyboards
+
+- `extraImports`: replaced by `modules` (https://github.com/AliSoftware/SwiftGen/pull/243)
+- `sceneEnumName`: has been replaced by `param.sceneEnumName`, should provide default value.
+- `segueEnumName`: has been replaced by `param.segueEnumName`, should provide default value.
+- For each `scene`:
+  - `isBaseViewController`: removed. You can replace it with a test for `baseType == "ViewController"`.
+
+#### Strings
+
+- `enumName`: has been replaced by `param.enumName`, should provide default value.
+- `strings` and `structuredStrings`: replaced by `tables` array, where each table has a structured `levels` property.
+- `tableName`: replaced by `tables` array, where each table has a `name` property.
+- for each `level`:
+  - `subenums`: renamed to `children`.
+- for each `string`:
+  - `keytail`: renamed to `name`.
+  - `params` structure with the `names`, `typednames`, `types`, `count` and `declarations` arrays: removed.
+  - These have been replaced by `types` which is an array of types. The previous variables
+ can now be reconstructed using template tags now that Stencil has become more powerful.
+
+### For developers using SwiftGenKit as a dependency:
+
+Previously the parser context generation method (`stencilContext()`) accepted parameters such as `enumName`, this has been removed in favor of the `--param` system. Templates will automatically receive a `param` object with parameters from the CLI invocation, and should provide default values in case no value was present in the invocation.

--- a/Sources/Stencil/AssetsCatalogContext.swift
+++ b/Sources/Stencil/AssetsCatalogContext.swift
@@ -18,7 +18,7 @@ import Foundation
        - `value`: `String` — the actual full name for loading the image
 */
 extension AssetsCatalogParser {
-  public func stencilContext(enumName: String = "Asset") -> [String: Any] {
+  public func stencilContext() -> [String: Any] {
     let catalogs = self.catalogs.keys.sorted(by: <).map { name -> [String: Any] in
       return [
         "name": name,

--- a/Sources/Stencil/ColorsContext.swift
+++ b/Sources/Stencil/ColorsContext.swift
@@ -15,7 +15,7 @@ import Foundation
     - `alpha`: `String` — hex value of the alpha component
 */
 extension ColorsFileParser {
-  public func stencilContext(enumName: String = "ColorName") -> [String: Any] {
+  public func stencilContext() -> [String: Any] {
     let colorMap = colors.map({ (color: (name: String, value: UInt32)) -> [String:String] in
       let name = color.name.trimmingCharacters(in: CharacterSet.whitespaces)
       let hex = "00000000" + String(color.value, radix: 16)

--- a/Sources/Stencil/FontsContext.swift
+++ b/Sources/Stencil/FontsContext.swift
@@ -16,7 +16,7 @@ import Foundation
 */
 
 extension FontsFileParser {
-  public func stencilContext(enumName: String = "FontFamily") -> [String: Any] {
+  public func stencilContext() -> [String: Any] {
     // turn into array of dictionaries
     let families = entries.map { (name: String, family: Set<Font>) -> [String: Any] in
       let fonts = family.map { (font: Font) -> [String: String] in

--- a/Sources/Stencil/StoryboardsContext.swift
+++ b/Sources/Stencil/StoryboardsContext.swift
@@ -34,8 +34,7 @@ private func uppercaseFirst(_ string: String) -> String {
        - `customModule`: `String` — The custom module of the segue (absent if no custom segue class)
 */
 extension StoryboardParser {
-  public func stencilContext(sceneEnumName: String = "StoryboardScene",
-                             segueEnumName: String = "StoryboardSegue") -> [String: Any] {
+  public func stencilContext() -> [String: Any] {
     let storyboards = Set(storyboardsScenes.keys).union(storyboardsSegues.keys).sorted(by: <)
     let storyboardsMap = storyboards.map { (storyboardName: String) -> [String:Any] in
       var sbMap: [String:Any] = ["name": storyboardName]

--- a/Sources/Stencil/StringsContext.swift
+++ b/Sources/Stencil/StringsContext.swift
@@ -29,7 +29,7 @@ private extension String {
           Contains a list of types like `"String"`, `"Int"`, etc
 */
 extension StringsFileParser {
-  public func stencilContext(enumName: String = "L10n", tableName: String = "Localizable") -> [String: Any] {
+  public func stencilContext() -> [String: Any] {
 
     let entryToStringMapper = { (entry: Entry, keyPath: [String]) -> [String: Any] in
       let levelName = entry.keyStructure.last ?? ""
@@ -52,7 +52,7 @@ extension StringsFileParser {
       usingMapper: entryToStringMapper
     )
     let tables: [[String: Any]] = [[
-      "name": tableName,
+      "name": "Localizable",
       "levels": structuredStrings
     ]]
 

--- a/Tests/SwiftGenKitTests/ColorsCLRFileTests.swift
+++ b/Tests/SwiftGenKitTests/ColorsCLRFileTests.swift
@@ -23,15 +23,6 @@ class ColorsCLRFileTests: XCTestCase {
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "defaults.plist", sub: .colors)
   }
-
-  func testFileWithCustomName() throws {
-    let parser = ColorsCLRFileParser()
-    try parser.parseFile(at: Fixtures.path(for: "colors.clr", sub: .colors))
-
-    let result = parser.stencilContext(enumName: "XCTColors")
-    XCTDiffContexts(result, expected: "customname.plist", sub: .colors)
-  }
-
   func testFileWithBadFile() {
     let parser = ColorsCLRFileParser()
     do {

--- a/Tests/SwiftGenKitTests/ColorsJSONFileTests.swift
+++ b/Tests/SwiftGenKitTests/ColorsJSONFileTests.swift
@@ -24,14 +24,6 @@ class ColorsJSONFileTests: XCTestCase {
     XCTDiffContexts(result, expected: "defaults.plist", sub: .colors)
   }
 
-  func testFileWithCustomName() throws {
-    let parser = ColorsJSONFileParser()
-    try parser.parseFile(at: Fixtures.path(for: "colors.json", sub: .colors))
-
-    let result = parser.stencilContext(enumName: "XCTColors")
-    XCTDiffContexts(result, expected: "customname.plist", sub: .colors)
-  }
-
   func testFileWithBadSyntax() {
     let parser = ColorsJSONFileParser()
     do {

--- a/Tests/SwiftGenKitTests/ColorsTextFileTests.swift
+++ b/Tests/SwiftGenKitTests/ColorsTextFileTests.swift
@@ -35,14 +35,6 @@ class ColorsTextFileTests: XCTestCase {
     XCTDiffContexts(result, expected: "text-defaults.plist", sub: .colors)
   }
 
-  func testFileWithCustomName() throws {
-    let parser = ColorsTextFileParser()
-    try parser.parseFile(at: Fixtures.path(for: "colors.txt", sub: .colors))
-
-    let result = parser.stencilContext(enumName: "XCTColors")
-    XCTDiffContexts(result, expected: "text-customname.plist", sub: .colors)
-  }
-
   func testFileWithBadSyntax() {
     let parser = ColorsTextFileParser()
     do {

--- a/Tests/SwiftGenKitTests/ColorsXMLFileTests.swift
+++ b/Tests/SwiftGenKitTests/ColorsXMLFileTests.swift
@@ -24,14 +24,6 @@ class ColorsXMLFileTests: XCTestCase {
     XCTDiffContexts(result, expected: "defaults.plist", sub: .colors)
   }
 
-  func testFileWithCustomName() throws {
-    let parser = ColorsXMLFileParser()
-    try parser.parseFile(at: Fixtures.path(for: "colors.xml", sub: .colors))
-
-    let result = parser.stencilContext(enumName: "XCTColors")
-    XCTDiffContexts(result, expected: "customname.plist", sub: .colors)
-  }
-
   func testFileWithBadSyntax() {
     let parser = ColorsXMLFileParser()
     do {

--- a/Tests/SwiftGenKitTests/FontsTests.swift
+++ b/Tests/SwiftGenKitTests/FontsTests.swift
@@ -25,12 +25,4 @@ class FontsTests: XCTestCase {
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "defaults.plist", sub: .fonts)
   }
-
-  func testCustomName() {
-    let parser = FontsFileParser()
-    parser.parseFile(at: Fixtures.directory(sub: .fonts))
-
-    let result = parser.stencilContext(enumName: "CustomFamily")
-    XCTDiffContexts(result, expected: "customname.plist", sub: .fonts)
-  }
 }

--- a/Tests/SwiftGenKitTests/ImagesTests.swift
+++ b/Tests/SwiftGenKitTests/ImagesTests.swift
@@ -22,19 +22,11 @@ class ImagesTests: XCTestCase {
     XCTDiffContexts(result, expected: "empty.plist", sub: .images)
   }
 
-  func testFileWithDefaults() {
+  func testDefaults() {
     let parser = AssetsCatalogParser()
     parser.parseCatalog(at: Fixtures.path(for: "Images.xcassets", sub: .images))
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "defaults.plist", sub: .images)
-  }
-
-  func testFileWithCustomName() {
-    let parser = AssetsCatalogParser()
-    parser.parseCatalog(at: Fixtures.path(for: "Images.xcassets", sub: .images))
-
-    let result = parser.stencilContext(enumName: "XCTImages")
-    XCTDiffContexts(result, expected: "customname.plist", sub: .images)
   }
 }

--- a/Tests/SwiftGenKitTests/StoryboardsMacOSTests.swift
+++ b/Tests/SwiftGenKitTests/StoryboardsMacOSTests.swift
@@ -21,7 +21,7 @@ class StoryboardsMacOSTests: XCTestCase {
     XCTDiffContexts(result, expected: "empty.plist", sub: .storyboardsMacOS)
   }
 
-  func testMessageStoryboardWithDefaults() {
+  func testMessageStoryboard() {
     let parser = StoryboardParser()
     do {
       try parser.addStoryboard(at: Fixtures.path(for: "Message.storyboard", sub: .storyboardsMacOS))
@@ -33,7 +33,7 @@ class StoryboardsMacOSTests: XCTestCase {
     XCTDiffContexts(result, expected: "messages.plist", sub: .storyboardsMacOS)
   }
 
-  func testAnonymousStoryboardWithDefaults() {
+  func testAnonymousStoryboard() {
     let parser = StoryboardParser()
     do {
       try parser.addStoryboard(at: Fixtures.path(for: "Anonymous.storyboard", sub: .storyboardsMacOS))
@@ -45,7 +45,7 @@ class StoryboardsMacOSTests: XCTestCase {
     XCTDiffContexts(result, expected: "anonymous.plist", sub: .storyboardsMacOS)
   }
 
-  func testAllStoryboardsWithDefaults() {
+  func testAllStoryboards() {
     let parser = StoryboardParser()
     do {
       try parser.parseDirectory(at: Fixtures.directory(sub: .storyboardsMacOS))
@@ -55,17 +55,5 @@ class StoryboardsMacOSTests: XCTestCase {
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "all.plist", sub: .storyboardsMacOS)
-  }
-
-  func testAllStoryboardsWithCustomName() {
-    let parser = StoryboardParser()
-    do {
-      try parser.parseDirectory(at: Fixtures.directory(sub: .storyboardsMacOS))
-    } catch {
-      print("Error: \(error.localizedDescription)")
-    }
-
-    let result = parser.stencilContext(sceneEnumName: "XCTStoryboardsScene", segueEnumName: "XCTStoryboardsSegue")
-    XCTDiffContexts(result, expected: "customname.plist", sub: .storyboardsMacOS)
   }
 }

--- a/Tests/SwiftGenKitTests/StoryboardsiOSTests.swift
+++ b/Tests/SwiftGenKitTests/StoryboardsiOSTests.swift
@@ -22,7 +22,7 @@ class StoryboardsiOSTests: XCTestCase {
     XCTDiffContexts(result, expected: "empty.plist", sub: .storyboardsiOS)
   }
 
-  func testMessageStoryboardWithDefaults() {
+  func testMessageStoryboard() {
     let parser = StoryboardParser()
     do {
       try parser.addStoryboard(at: Fixtures.path(for: "Message.storyboard", sub: .storyboardsiOS))
@@ -34,7 +34,7 @@ class StoryboardsiOSTests: XCTestCase {
     XCTDiffContexts(result, expected: "messages.plist", sub: .storyboardsiOS)
   }
 
-  func testAnonymousStoryboardWithDefaults() {
+  func testAnonymousStoryboard() {
     let parser = StoryboardParser()
     do {
       try parser.addStoryboard(at: Fixtures.path(for: "Anonymous.storyboard", sub: .storyboardsiOS))
@@ -46,7 +46,7 @@ class StoryboardsiOSTests: XCTestCase {
     XCTDiffContexts(result, expected: "anonymous.plist", sub: .storyboardsiOS)
   }
 
-  func testAllStoryboardsWithDefaults() {
+  func testAllStoryboards() {
     let parser = StoryboardParser()
     do {
       try parser.parseDirectory(at: Fixtures.directory(sub: .storyboardsiOS))
@@ -56,17 +56,5 @@ class StoryboardsiOSTests: XCTestCase {
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "all.plist", sub: .storyboardsiOS)
-  }
-
-  func testAllStoryboardsWithCustomName() {
-    let parser = StoryboardParser()
-    do {
-      try parser.parseDirectory(at: Fixtures.directory(sub: .storyboardsiOS))
-    } catch {
-      print("Error: \(error.localizedDescription)")
-    }
-
-    let result = parser.stencilContext(sceneEnumName: "XCTStoryboardsScene", segueEnumName: "XCTStoryboardsSegue")
-    XCTDiffContexts(result, expected: "customname.plist", sub: .storyboardsiOS)
   }
 }

--- a/Tests/SwiftGenKitTests/StringsTests.swift
+++ b/Tests/SwiftGenKitTests/StringsTests.swift
@@ -21,24 +21,12 @@ class StringsTests: XCTestCase {
     XCTDiffContexts(result, expected: "empty.plist", sub: .strings)
   }
 
-  func testEntriesWithDefaults() {
-    let parser = StringsFileParser()
-    parser.addEntry(StringsFileParser.Entry(key: "Title",
-                                            translation: "My awesome title"))
-    parser.addEntry(StringsFileParser.Entry(key: "Greetings",
-                                            translation: "Hello, my name is %@ and I'm %d",
-                                            types: .object, .int))
-
-    let result = parser.stencilContext()
-    XCTDiffContexts(result, expected: "entries.plist", sub: .strings)
-  }
-
-  func testFileWithDefaults() throws {
+  func testLocalizable() throws {
     let parser = StringsFileParser()
     try parser.parseFile(at: Fixtures.path(for: "Localizable.strings", sub: .strings))
 
     let result = parser.stencilContext()
-    XCTDiffContexts(result, expected: "defaults.plist", sub: .strings)
+    XCTDiffContexts(result, expected: "localizable.plist", sub: .strings)
   }
 
   func testMultiline() throws {
@@ -49,7 +37,7 @@ class StringsTests: XCTestCase {
     XCTDiffContexts(result, expected: "multiline.plist", sub: .strings)
   }
 
-  func testUTF8FileWithDefaults() throws {
+  func testUTF8File() throws {
     let parser = StringsFileParser()
     try parser.parseFile(at: Fixtures.path(for: "LocUTF8.strings", sub: .strings))
 
@@ -57,15 +45,7 @@ class StringsTests: XCTestCase {
     XCTDiffContexts(result, expected: "utf8.plist", sub: .strings)
   }
 
-  func testFileWithCustomName() throws {
-    let parser = StringsFileParser()
-    try parser.parseFile(at: Fixtures.path(for: "Localizable.strings", sub: .strings))
-
-    let result = parser.stencilContext(enumName: "XCTLoc")
-    XCTDiffContexts(result, expected: "customname.plist", sub: .strings)
-  }
-
-  func testFileWithStructuredOnly() throws {
+  func testStructuredOnly() throws {
     let parser = StringsFileParser()
     try parser.parseFile(at: Fixtures.path(for: "LocStructuredOnly.strings", sub: .strings))
 


### PR DESCRIPTION
This a leftover after #35 was merged.
Inherently, this also removes some old tests that are now covered by context variations in the `templates` repository.

Refs https://github.com/SwiftGen/templates/pull/50.