### PR TITLE
Error for wrong type placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@ Due to the removal of legacy code, there are a few breaking changes in this new 
 
 ### New Features
 
-_None_
+* Throw an error if a format string has mismatching types for the same placeholde position.  
+  [David Jennes](https://github.com/djbe)
+  [#44](https://github.com/SwiftGen/SwiftGenKit/issues/44)
 
 ### Internal Changes
 

--- a/Tests/SwiftGenKitTests/StringParserTests.swift
+++ b/Tests/SwiftGenKitTests/StringParserTests.swift
@@ -8,56 +8,72 @@ import XCTest
 import SwiftGenKit
 
 class StringParserTests: XCTestCase {
-  func testParseStringPlaceholder() {
-    let placeholders = StringsFileParser.PlaceholderType.placeholders(fromFormat: "%@")
+  func testParseStringPlaceholder() throws {
+    let placeholders = try StringsFileParser.PlaceholderType.placeholders(fromFormat: "%@")
     XCTAssertEqual(placeholders, [.object])
   }
 
-  func testParseFloatPlaceholder() {
-    let placeholders = StringsFileParser.PlaceholderType.placeholders(fromFormat: "%f")
+  func testParseFloatPlaceholder() throws {
+    let placeholders = try StringsFileParser.PlaceholderType.placeholders(fromFormat: "%f")
     XCTAssertEqual(placeholders, [.float])
   }
 
-  func testParseDoublePlaceholders() {
-    let placeholders = StringsFileParser.PlaceholderType.placeholders(fromFormat: "%g-%e")
+  func testParseDoublePlaceholders() throws {
+    let placeholders = try StringsFileParser.PlaceholderType.placeholders(fromFormat: "%g-%e")
     XCTAssertEqual(placeholders, [.float, .float])
   }
 
-  func testParseFloatWithPrecisionPlaceholders() {
-    let placeholders = StringsFileParser.PlaceholderType.placeholders(fromFormat: "%1.2f : %.3f : %+3f : %-6.2f")
+  func testParseFloatWithPrecisionPlaceholders() throws {
+    let placeholders = try StringsFileParser.PlaceholderType.placeholders(fromFormat: "%1.2f : %.3f : %+3f : %-6.2f")
     XCTAssertEqual(placeholders, [.float, .float, .float, .float])
   }
 
-  func testParseIntPlaceholders() {
-    let placeholders = StringsFileParser.PlaceholderType.placeholders(fromFormat: "%d-%i-%o-%u-%x")
+  func testParseIntPlaceholders() throws {
+    let placeholders = try StringsFileParser.PlaceholderType.placeholders(fromFormat: "%d-%i-%o-%u-%x")
     XCTAssertEqual(placeholders, [.int, .int, .int, .int, .int])
   }
 
-  func testParseCCharAndStringPlaceholders() {
-    let placeholders = StringsFileParser.PlaceholderType.placeholders(fromFormat: "%c-%s")
+  func testParseCCharAndStringPlaceholders() throws {
+    let placeholders = try StringsFileParser.PlaceholderType.placeholders(fromFormat: "%c-%s")
     XCTAssertEqual(placeholders, [.char, .cString])
   }
 
-  func testParsePositionalPlaceholders() {
-    let placeholders = StringsFileParser.PlaceholderType.placeholders(fromFormat: "%2$d-%4$f-%3$@-%c")
+  func testParsePositionalPlaceholders() throws {
+    let placeholders = try StringsFileParser.PlaceholderType.placeholders(fromFormat: "%2$d-%4$f-%3$@-%c")
     XCTAssertEqual(placeholders, [.char, .int, .object, .float])
   }
 
-  func testParseComplexFormatPlaceholders() {
+  func testParseComplexFormatPlaceholders() throws {
     let format = "%2$1.3d - %4$-.7f - %3$@ - %% - %5$+3c - %%"
-    let placeholders = StringsFileParser.PlaceholderType.placeholders(fromFormat: format)
+    let placeholders = try StringsFileParser.PlaceholderType.placeholders(fromFormat: format)
     // positions 2, 4, 3, 5 set to Int, Float, Object, Char, and position 1 not matched, defaulting to Unknown
     XCTAssertEqual(placeholders, [.unknown, .int, .object, .float, .char])
   }
 
-  func testParseEvenEscapePercentSign() {
-    let placeholders = StringsFileParser.PlaceholderType.placeholders(fromFormat: "%%foo")
+  func testParseDuplicateFormatPlaceholders() throws {
+    let placeholders = try StringsFileParser.PlaceholderType.placeholders(fromFormat: "Text: %1$@; %1$@.")
+    XCTAssertEqual(placeholders, [.object])
+  }
+
+  func testParseErrorOnTypeMismatch() throws {
+    do {
+      _ = try StringsFileParser.PlaceholderType.placeholders(fromFormat: "Text: %1$@; %1$ld.")
+      XCTFail("Code did parse string successfully while it was expected to fail for bad syntax")
+    } catch StringsFileParserError.invalidPlaceholder {
+      // That's the expected exception we want to happen
+    } catch let error {
+      XCTFail("Unexpected error occured while parsing: \(error)")
+    }
+  }
+
+  func testParseEvenEscapePercentSign() throws {
+    let placeholders = try StringsFileParser.PlaceholderType.placeholders(fromFormat: "%%foo")
     // Must NOT map to [.float]
     XCTAssertEqual(placeholders, [])
   }
 
-  func testParseOddEscapePercentSign() {
-    let placeholders = StringsFileParser.PlaceholderType.placeholders(fromFormat: "%%%foo")
+  func testParseOddEscapePercentSign() throws {
+    let placeholders = try StringsFileParser.PlaceholderType.placeholders(fromFormat: "%%%foo")
     // Should map to [.float]
     XCTAssertEqual(placeholders, [.float])
   }


### PR DESCRIPTION
Throws an error if placeholders in a format string (for the same position) have different types, for example:
> "Text: %1$@; %1$ld."

Fixes https://github.com/SwiftGen/SwiftGen/issues/309.