### PR TITLE
Storyboard runtime target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ Due to the removal of legacy code, there are a few breaking changes in this new 
 * Added support for multiple string tables.   
   [David Jennes](https://github.com/djbe)
   [#41](https://github.com/SwiftGen/templates/issues/41)
+* Storyboards now provide a `platform` identifier (iOS, macOS, tvOS, watchOS).  
+  [David Jennes](https://github.com/djbe)
+  [#45](https://github.com/SwiftGen/templates/issues/45)
 
 ### Internal Changes
 

--- a/Documentation/Storyboards.md
+++ b/Documentation/Storyboards.md
@@ -9,20 +9,18 @@ The storyboards parser accepts either a file or a directory, which it'll search 
 The output context has the following structure:
 
  - `modules`    : `Array<String>` — List of modules used by scenes and segues — typically to be used for "import" statements
+ - `platform`   : `String` — Name of the target platform (only available if all storyboards target the same platform)
  - `storyboards`: `Array` — List of storyboards
     - `name`: `String` — Name of the storyboard
-    - `initialScene`: `Dictionary` (absent if not specified)
-       - `customClass` : `String` — The custom class of the scene (absent if generic UIViewController/NSViewController)
-       - `customModule`: `String` — The custom module of the scene (absent if no custom class)
-       - `baseType`: `String` — The base class type of the scene if not custom (absent if class is a custom class).
-          Possible values include 'ViewController', 'NavigationController', 'TableViewController'…
-    - `scenes`: `Array` (absent if empty)
+    - `platform`: `String` — Name of the target platform (iOS, macOS, tvOS, watchOS)
+    - `initialScene`: `Dictionary` — Same structure as scenes item (absent if not specified)
+    - `scenes`: `Array` - List of scenes
        - `identifier` : `String` — The scene identifier
        - `customClass`: `String` — The custom class of the scene (absent if generic UIViewController/NSViewController)
        - `customModule`: `String` — The custom module of the scene (absent if no custom class)
        - `baseType`: `String` — The base class type of the scene if not custom (absent if class is a custom class).
           Possible values include 'ViewController', 'NavigationController', 'TableViewController'…
-    - `segues`: `Array` (absent if empty)
+    - `segues`: `Array` - List of segues
        - `identifier`: `String` — The segue identifier
        - `customClass`: `String` — The custom class of the segue (absent if generic UIStoryboardSegue)
        - `customModule`: `String` — The custom module of the segue (absent if no custom segue class)

--- a/Sources/Parsers/StoryboardParser.swift
+++ b/Sources/Parsers/StoryboardParser.swift
@@ -8,46 +8,65 @@ import Foundation
 import Kanna
 import PathKit
 
-public final class StoryboardParser {
-  struct InitialScene {
-    let tag: String
-    let customClass: String?
-    let customModule: String?
+private enum XML {
+  enum Scene {
+    static let initialVCXPath = "/*/@initialViewController"
+    static let targetRuntimeXPath = "/*/@targetRuntime"
+    static func initialSceneXPath(identifier: String) -> String {
+      return "/document/scenes/scene/objects/*[@sceneMemberID=\"viewController\" and @id=\"\(identifier)\"]"
+    }
+    static func sceneXPath(initial: String) -> String {
+      return "/document/scenes/scene/objects/*[@sceneMemberID=\"viewController\" and " +
+        "string-length(@storyboardIdentifier) > 0]"
+    }
+    static let placeholderTag = "viewControllerPlaceholder"
+    static let customClassAttribute = "customClass"
+    static let customModuleAttribute = "customModule"
+    static let storyboardIdentifierAttribute = "storyboardIdentifier"
   }
+  enum Segue {
+    static let segueXPath = "/document/scenes/scene//connections/segue[string(@identifier)]"
+    static let identifierAttribute = "identifier"
+    static let customClassAttribute = "customClass"
+    static let customModuleAttribute = "customModule"
+  }
+}
 
+struct Storyboard {
   struct Scene {
-    let storyboardID: String
+    let identifier: String
     let tag: String
     let customClass: String?
     let customModule: String?
+
+    init(with object: Kanna.XMLElement) {
+      identifier = object[XML.Scene.storyboardIdentifierAttribute] ?? ""
+      tag = object.tagName ?? ""
+      customClass = object[XML.Scene.customClassAttribute]
+      customModule = object[XML.Scene.customModuleAttribute]
+    }
   }
 
   struct Segue {
     let identifier: String
     let customClass: String?
     let customModule: String?
+
+    init(with object: Kanna.XMLElement) {
+      identifier = object[XML.Segue.identifierAttribute] ?? ""
+      customClass = object[XML.Segue.customClassAttribute]
+      customModule = object[XML.Segue.customModuleAttribute]
+    }
   }
 
-  enum XMLScene {
-    static let initialVCXPath = "/*/@initialViewController"
-    static let sceneXPath = "/document/scenes/scene/objects/*[@sceneMemberID=\"viewController\"]"
-    static let placeholderTag = "viewControllerPlaceholder"
-    static let customClassAttribute = "customClass"
-    static let customModuleAttribute = "customModule"
-    static let idAttribute = "id"
-    static let storyboardIdentifierAttribute = "storyboardIdentifier"
-  }
-  enum XMLSegue {
-    static let segueXPath = "/document/scenes/scene//connections/segue[string(@identifier)]"
-    static let identifierAttribute = "identifier"
-    static let customClassAttribute = "customClass"
-    static let customModuleAttribute = "customModule"
-  }
+  let name: String
+  let initialScene: Scene?
+  let scenes: Set<Scene>
+  let segues: Set<Segue>
+}
 
-  var initialScenes = [String: InitialScene]()
-  var storyboardsScenes = [String: Set<Scene>]()
-  var storyboardsSegues = [String: Set<Segue>]()
-  var modules = Set<String>()
+public final class StoryboardParser {
+  var storyboards = [Storyboard]()
 
   public init() {}
 
@@ -56,44 +75,28 @@ public final class StoryboardParser {
       throw ColorsParserError.invalidFile(reason: "Unknown XML parser error.")
     }
 
-    let storyboardName = path.lastComponentWithoutExtension
-    let initialSceneID = document.at_xpath(XMLScene.initialVCXPath)?.text
-    var initialScene: InitialScene? = nil
-    var scenes = Set<Scene>()
-    var segues = Set<Segue>()
-
-    for scene in document.xpath(XMLScene.sceneXPath) {
-      guard scene.tagName != XMLScene.placeholderTag else { continue }
-
-      let customClass = scene[XMLScene.customClassAttribute]
-      let customModule = scene[XMLScene.customModuleAttribute]
-
-      if scene[XMLScene.idAttribute] == initialSceneID {
-        initialScene = InitialScene(tag: scene.tagName ?? "",
-                                    customClass: customClass,
-                                    customModule: customModule)
-      }
-      if let id = scene[XMLScene.storyboardIdentifierAttribute] {
-        scenes.insert(Scene(storyboardID: id,
-                            tag: scene.tagName ?? "",
-                            customClass: customClass,
-                            customModule: customModule))
-      }
+    // Initial VC
+    let initialSceneID = document.at_xpath(XML.Scene.initialVCXPath)?.text ?? ""
+    var initialScene: Storyboard.Scene? = nil
+    if let object = document.at_xpath(XML.Scene.initialSceneXPath(identifier: initialSceneID)) {
+      initialScene = Storyboard.Scene(with: object)
     }
 
-    for segue in document.xpath(XMLSegue.segueXPath) {
-      let id = segue[XMLSegue.identifierAttribute] ?? ""
-      let customClass = segue[XMLSegue.customClassAttribute]
-      let customModule = segue[XMLSegue.customModuleAttribute]
+    // Scenes
+    let scenes = Set<Storyboard.Scene>(document.xpath(XML.Scene.sceneXPath(initial: initialSceneID)).flatMap {
+      guard $0.tagName != XML.Scene.placeholderTag else { return nil }
+      return Storyboard.Scene(with: $0)
+    })
 
-      segues.insert(Segue(identifier: id, customClass: customClass, customModule: customModule))
-    }
+    // Segues
+    let segues = Set<Storyboard.Segue>(document.xpath(XML.Segue.segueXPath).map {
+      Storyboard.Segue(with: $0)
+    })
 
-    initialScenes[storyboardName] = initialScene
-    storyboardsScenes[storyboardName] = scenes
-    storyboardsSegues[storyboardName] = segues
-
-    modules.formUnion(collectModules(initial: initialScene, scenes: scenes, segues: segues))
+    storyboards += [Storyboard(name: path.lastComponentWithoutExtension,
+                               initialScene: initialScene,
+                               scenes: scenes,
+                               segues: segues)]
   }
 
   public func parseDirectory(at path: Path) throws {
@@ -106,41 +109,44 @@ public final class StoryboardParser {
     }
   }
 
-  private func collectModules(initial: InitialScene?, scenes: Set<Scene>, segues: Set<Segue>) -> Set<String> {
-    var result = Set<String>()
+  var modules: Set<String> {
+    return Set<String>(storyboards.flatMap(collectModules(from:)))
+  }
 
-    if let module = initial?.customModule {
-      result.insert(module)
+  private func collectModules(from storyboard: Storyboard) -> [String] {
+    var result: [String] = storyboard.scenes.flatMap { $0.customModule } +
+      storyboard.segues.flatMap { $0.customModule }
+
+    if let module = storyboard.initialScene?.customModule {
+      result += [module]
     }
-    result.formUnion(Set<String>(scenes.flatMap { $0.customModule }))
-    result.formUnion(Set<String>(segues.flatMap { $0.customModule }))
 
     return result
   }
 }
 
-extension StoryboardParser.Scene: Equatable { }
-func == (lhs: StoryboardParser.Scene, rhs: StoryboardParser.Scene) -> Bool {
-  return lhs.storyboardID == rhs.storyboardID &&
+extension Storyboard.Scene: Equatable { }
+func == (lhs: Storyboard.Scene, rhs: Storyboard.Scene) -> Bool {
+  return lhs.identifier == rhs.identifier &&
     lhs.tag == rhs.tag &&
     lhs.customClass == rhs.customClass &&
     lhs.customModule == rhs.customModule
 }
 
-extension StoryboardParser.Scene: Hashable {
+extension Storyboard.Scene: Hashable {
   var hashValue: Int {
-    return storyboardID.hashValue ^ tag.hashValue ^ (customModule?.hashValue ?? 0) ^ (customClass?.hashValue ?? 0)
+    return identifier.hashValue ^ tag.hashValue ^ (customModule?.hashValue ?? 0) ^ (customClass?.hashValue ?? 0)
   }
 }
 
-extension StoryboardParser.Segue: Equatable { }
-func == (lhs: StoryboardParser.Segue, rhs: StoryboardParser.Segue) -> Bool {
+extension Storyboard.Segue: Equatable { }
+func == (lhs: Storyboard.Segue, rhs: Storyboard.Segue) -> Bool {
   return lhs.identifier == rhs.identifier &&
     lhs.customClass == rhs.customClass &&
     lhs.customModule == rhs.customModule
 }
 
-extension StoryboardParser.Segue: Hashable {
+extension Storyboard.Segue: Hashable {
   var hashValue: Int {
     return identifier.hashValue ^ (customModule?.hashValue ?? 0) ^ (customClass?.hashValue ?? 0)
   }

--- a/Sources/Parsers/StoryboardParser.swift
+++ b/Sources/Parsers/StoryboardParser.swift
@@ -101,7 +101,7 @@ public final class StoryboardParser {
       "MacOSX.Cocoa": "macOS",
       "watchKit": "watchOS"
     ]
-    var targetRuntime = document.at_xpath(XML.Scene.targetRuntimeXPath)?.text ?? ""
+    let targetRuntime = document.at_xpath(XML.Scene.targetRuntimeXPath)?.text ?? ""
     let platform = mapping[targetRuntime] ?? targetRuntime
 
     storyboards += [Storyboard(name: path.lastComponentWithoutExtension,
@@ -134,6 +134,16 @@ public final class StoryboardParser {
     }
 
     return result
+  }
+
+  var platform: String? {
+    let platforms = Set<String>(storyboards.map { $0.platform })
+
+    if platforms.count > 1 {
+      return nil
+    } else {
+      return platforms.first
+    }
   }
 }
 

--- a/Sources/Parsers/StoryboardParser.swift
+++ b/Sources/Parsers/StoryboardParser.swift
@@ -60,6 +60,7 @@ struct Storyboard {
   }
 
   let name: String
+  let platform: String
   let initialScene: Scene?
   let scenes: Set<Scene>
   let segues: Set<Segue>
@@ -93,7 +94,18 @@ public final class StoryboardParser {
       Storyboard.Segue(with: $0)
     })
 
+    // TargetRuntime
+    let mapping = [
+      "AppleTV": "tvOS",
+      "iOS.CocoaTouch": "iOS",
+      "MacOSX.Cocoa": "macOS",
+      "watchKit": "watchOS"
+    ]
+    var targetRuntime = document.at_xpath(XML.Scene.targetRuntimeXPath)?.text ?? ""
+    let platform = mapping[targetRuntime] ?? targetRuntime
+
     storyboards += [Storyboard(name: path.lastComponentWithoutExtension,
+                               platform: platform,
                                initialScene: initialScene,
                                scenes: scenes,
                                segues: segues)]

--- a/Sources/Stencil/StoryboardsContext.swift
+++ b/Sources/Stencil/StoryboardsContext.swift
@@ -40,7 +40,8 @@ extension StoryboardParser {
       .map(map(storyboard:))
     return [
       "modules": modules.sorted(),
-      "storyboards": storyboards
+      "storyboards": storyboards,
+      "platform": platform ?? ""
     ]
   }
 

--- a/Sources/Stencil/StoryboardsContext.swift
+++ b/Sources/Stencil/StoryboardsContext.swift
@@ -52,7 +52,8 @@ extension StoryboardParser {
         .map(map(scene:)),
       "segues": storyboard.segues
         .sorted { $0.identifier < $1.identifier }
-        .map(map(segue:))
+        .map(map(segue:)),
+      "platform": storyboard.platform
     ]
 
     if let scene = storyboard.initialScene {

--- a/Sources/Stencil/StoryboardsContext.swift
+++ b/Sources/Stencil/StoryboardsContext.swift
@@ -15,20 +15,18 @@ private func uppercaseFirst(_ string: String) -> String {
 
 /*
  - `modules`    : `Array<String>` — List of modules used by scenes and segues — typically used for "import" statements
+ - `platform`   : `String` — Name of the target platform (only available if all storyboards target the same platform)
  - `storyboards`: `Array` — List of storyboards
     - `name`: `String` — Name of the storyboard
-    - `initialScene`: `Dictionary` (absent if not specified)
-       - `customClass` : `String` — The custom class of the scene (absent if generic UIViewController/NSViewController)
-       - `customModule`: `String` — The custom module of the scene (absent if no custom class)
-       - `baseType`: `String` — The base class type of the scene if not custom (absent if class is a custom class).
-          Possible values include 'ViewController', 'NavigationController', 'TableViewController'…
-    - `scenes`: `Array` (absent if empty)
+    - `platform`: `String` — Name of the target platform (iOS, macOS, tvOS, watchOS)
+    - `initialScene`: `Dictionary` — Same structure as scenes item (absent if not specified)
+    - `scenes`: `Array` - List of scenes
        - `identifier` : `String` — The scene identifier
        - `customClass`: `String` — The custom class of the scene (absent if generic UIViewController/NSViewController)
        - `customModule`: `String` — The custom module of the scene (absent if no custom class)
        - `baseType`: `String` — The base class type of the scene if not custom (absent if class is a custom class).
           Possible values include 'ViewController', 'NavigationController', 'TableViewController'…
-    - `segues`: `Array` (absent if empty)
+    - `segues`: `Array` - List of segues
        - `identifier`: `String` — The segue identifier
        - `customClass`: `String` — The custom class of the segue (absent if generic UIStoryboardSegue)
        - `customModule`: `String` — The custom module of the segue (absent if no custom segue class)


### PR DESCRIPTION
Somehow Github didn't show the create PR button for this one.

Adds a `platform` variable to the context for each storyboard, and also at the top level if all storyboards have the same platform. This PR also refactors the parsing code a bit to unify the `InitialScene` and `Scene` objects (they are essentially the same, thus the change).

Context changes in https://github.com/SwiftGen/templates/pull/52