### PR TITLE
Rename images subcommand to xcassets

### DIFF
--- a/Sources/Parsers/AssetsCatalogParser.swift
+++ b/Sources/Parsers/AssetsCatalogParser.swift
@@ -33,7 +33,7 @@ public final class AssetsCatalogParser: Parser {
   public var warningHandler: Parser.MessageHandler?
 
   public static let commandInfo = CommandInfo(
-    name: "assets",
+    name: "xcassets",
     description: "generate code for items in your Assets Catalog(s)",
     pathDescription: "Asset Catalog file(s)."
   )

--- a/Sources/Parsers/AssetsCatalogParser.swift
+++ b/Sources/Parsers/AssetsCatalogParser.swift
@@ -32,12 +32,6 @@ public final class AssetsCatalogParser: Parser {
   var catalogs = [Catalog]()
   public var warningHandler: Parser.MessageHandler?
 
-  public static let commandInfo = CommandInfo(
-    name: "xcassets",
-    description: "generate code for items in your Assets Catalog(s)",
-    pathDescription: "Asset Catalog file(s)."
-  )
-
   public init(options: [String: Any] = [:], warningHandler: Parser.MessageHandler? = nil) {
     self.warningHandler = warningHandler
   }

--- a/Sources/Parsers/ColorsParser.swift
+++ b/Sources/Parsers/ColorsParser.swift
@@ -43,12 +43,6 @@ public final class ColorsParser: Parser {
   var palettes = [Palette]()
   public var warningHandler: Parser.MessageHandler?
 
-  public static let commandInfo = CommandInfo(
-    name: "colors",
-    description: "generate code for color palettes",
-    pathDescription: "Colors.txt|.clr|.xml|.json file(s) to parse."
-  )
-
   public init(options: [String: Any] = [:], warningHandler: Parser.MessageHandler? = nil) {
     self.warningHandler = warningHandler
 

--- a/Sources/Parsers/FontsParser.swift
+++ b/Sources/Parsers/FontsParser.swift
@@ -78,12 +78,6 @@ public final class FontsParser: Parser {
   var entries: [String: Set<Font>] = [:]
   public var warningHandler: Parser.MessageHandler?
 
-  public static let commandInfo = CommandInfo(
-    name: "fonts",
-    description: "generate code for your fonts",
-    pathDescription: "Directory(ies) to parse."
-  )
-
   public init(options: [String: Any] = [:], warningHandler: Parser.MessageHandler? = nil) {
     self.warningHandler = warningHandler
   }

--- a/Sources/Parsers/Parser.swift
+++ b/Sources/Parsers/Parser.swift
@@ -7,17 +7,8 @@
 import Foundation
 import PathKit
 
-public struct CommandInfo {
-  public var name: String
-  public var description: String
-  public var pathDescription: String
-}
-
 public protocol Parser {
   init(options: [String: Any], warningHandler: MessageHandler?) throws
-
-  // Command info
-  static var commandInfo: CommandInfo { get }
 
   // Parsing and context generation
   func parse(path: Path) throws

--- a/Sources/Parsers/StoryboardParser.swift
+++ b/Sources/Parsers/StoryboardParser.swift
@@ -70,12 +70,6 @@ public final class StoryboardParser: Parser {
   var storyboards = [Storyboard]()
   public var warningHandler: Parser.MessageHandler?
 
-  public static let commandInfo = CommandInfo(
-    name: "storyboards",
-    description: "generate code for your storyboard scenes and segues",
-    pathDescription: "Directory to scan for .storyboard files. Can also be a path to a single .storyboard"
-  )
-
   public init(options: [String: Any] = [:], warningHandler: Parser.MessageHandler? = nil) {
     self.warningHandler = warningHandler
   }

--- a/Sources/Parsers/StringsParser.swift
+++ b/Sources/Parsers/StringsParser.swift
@@ -31,12 +31,6 @@ public final class StringsParser: Parser {
   var tables = [String: [Entry]]()
   public var warningHandler: Parser.MessageHandler?
 
-  public static let commandInfo = CommandInfo(
-    name: "strings",
-    description: "generate code for your Localizable.strings file(s)",
-    pathDescription: "Strings file(s) to parse."
-  )
-
   public init(options: [String: Any] = [:], warningHandler: Parser.MessageHandler? = nil) {
     self.warningHandler = warningHandler
   }

--- a/Tests/SwiftGenKitTests/AssetCatalogTests.swift
+++ b/Tests/SwiftGenKitTests/AssetCatalogTests.swift
@@ -13,14 +13,14 @@ class AssetCatalogTests: XCTestCase {
     let parser = AssetsCatalogParser()
 
     let result = parser.stencilContext()
-    XCTDiffContexts(result, expected: "empty.plist", sub: .images)
+    XCTDiffContexts(result, expected: "empty.plist", sub: .xcassets)
   }
 
   func testDefaults() throws {
     let parser = AssetsCatalogParser()
-    try parser.parse(path: Fixtures.path(for: "Images.xcassets", sub: .images))
+    try parser.parse(path: Fixtures.path(for: "Images.xcassets", sub: .xcassets))
 
     let result = parser.stencilContext()
-    XCTDiffContexts(result, expected: "defaults.plist", sub: .images)
+    XCTDiffContexts(result, expected: "defaults.plist", sub: .xcassets)
   }
 }

--- a/Tests/SwiftGenKitTests/TestsHelper.swift
+++ b/Tests/SwiftGenKitTests/TestsHelper.swift
@@ -92,7 +92,7 @@ class Fixtures {
   enum Directory: String {
     case colors = "Colors"
     case fonts = "Fonts"
-    case images = "Images"
+    case xcassets = "XCAssets"
     case storyboardsiOS = "Storyboards-iOS"
     case storyboardsMacOS = "Storyboards-macOS"
     case strings = "Strings"


### PR DESCRIPTION
☑️   Part 1 [here](https://github.com/SwiftGen/templates/pull/62)
➡️ Part 2 of SwiftGen/SwiftGen/issues/311
⬜️ Part 3 [here](https://github.com/SwiftGen/SwiftGen/pull/317)

⚠️ Once SwiftGen/templates#62 is merged, we should realign the submodule in this PR to point to the new templates' master