### PR TITLE
Revise entry name order in Assets Catalog

### DIFF
--- a/Sources/Stencil/AssetsCatalogContext.swift
+++ b/Sources/Stencil/AssetsCatalogContext.swift
@@ -28,9 +28,21 @@ extension AssetsCatalogParser {
     let catalogs = self.catalogs
       .sorted { lhs, rhs in lhs.name < rhs.name }
       .map { catalog -> [String: Any] in
+        let entries = catalog.entries.sorted { lhs, rhs in
+            if case let .group(lhsName, _) = lhs, case let .group(rhsName, _) = rhs {
+                return lhsName < rhsName
+            }
+            if case let .color(lhsName, _) = lhs, case let .color(rhsName, _) = rhs {
+                return lhsName < rhsName
+            }
+            if case let .image(lhsName, _) = lhs, case let .image(rhsName, _) = rhs {
+                return lhsName < rhsName
+            }
+            return false
+        }
         return [
           "name": catalog.name,
-          "assets": structure(entries: catalog.entries)
+          "assets": structure(entries: entries)
         ]
     }
 


### PR DESCRIPTION
I use SwiftGen in my project on macOS High Sierra, but I encountered a problem where the order of AssetCatalog image names is not guaranteed.
It was not a problem with macOS Sierra, but it seems to be a problem on High Sierra.
I fixed it so that the order is guaranteed.
